### PR TITLE
fix: Desktop(s) running command

### DIFF
--- a/fpaste
+++ b/fpaste
@@ -229,8 +229,8 @@ def sysinfo(
          'cat /etc/motd'),
         ('Kernel',             '''uname -r ; cat /proc/cmdline'''),
         ('Desktop(s) Running',
-         '''ps -eo comm= | grep -E
-         '(gnome-session|startkde|startactive|xfce.?-session|fluxbox|blackbox|hackedbox|ratpoison|enlightenment|icewm-session|od-session|wmaker|wmx|openbox-lxde|openbox-gnome-session|openbox-kde-session|mwm|e16|fvwm|xmonad|sugar-session|mate-session|lxqt-session|cinnamon)'
+         '''ps -eo comm= | grep -E \
+         '(gnome-session-b|gnome-session|startkde|startactive|xfce.?-session|fluxbox|blackbox|hackedbox|ratpoison|enlightenment|icewm-session|od-session|wmaker|wmx|openbox-lxde|openbox-gnome-session|openbox-kde-session|mwm|e16|fvwm|xmonad|sugar-session|mate-session|lxqt-session|cinnamon)'
          '''),
         ('Desktop(s) Installed',
          '''ls -m /usr/share/xsessions/ | sed 's/\.desktop//g' '''),


### PR DESCRIPTION
Desktop(s) Running command fails on F25 (eg: https://paste.fedoraproject.org/511254/14824404/) 

Commit fixes two things:
* adds missing \ causing command to fail
* adds gnome-session-b for F25 

(fixed eg. https://paste.fedoraproject.org/511307/24462751/)