### PR TITLE
Show PCI vendor and device codes in lspci output

### DIFF
--- a/fpaste
+++ b/fpaste
@@ -199,7 +199,7 @@ def sysinfo(
         ('Top 5 Memory hogs',  '''ps axuScnh | sort -rnk4 | head -5'''),
         ('Disk space usage',   '''df -hT''', 'df -h', 'df'),
         ('Block devices',      '''blkid''', '''/sbin/blkid'''),
-        ('PCI devices',        '''lspci''', '''/sbin/lspci'''),
+        ('PCI devices',        '''lspci -nn''', '''/sbin/lspci -nn''', '''lspci''', '''/sbin/lspci'''),
         ('USB devices',        '''lsusb''', '''/sbin/lsusb'''),
         ('DRM Information',
          '''journalctl -k -b | grep -o 'kernel:.*drm.*$' | cut -d ' ' -f 2- '''


### PR DESCRIPTION
Made a change so that PCI vendor and device codes are been shown in --sysinfo output. There is a fallback to old behaviour if 'lspci -nn' exits with a non-zero exit code.

```
root@beans:~# lspci
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.1 IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]
00:01.2 USB controller: Intel Corporation 82371SB PIIX3 USB [Natoma/Triton II] (rev 01)
00:01.3 Bridge: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 03)
00:02.0 VGA compatible controller: Device 1234:1111 (rev 02)
00:03.0 Ethernet controller: Red Hat, Inc Virtio network device
00:04.0 SCSI storage controller: Red Hat, Inc Virtio SCSI
00:05.0 Unclassified device [00ff]: Red Hat, Inc Virtio memory balloon
00:06.0 Communication controller: Red Hat, Inc Virtio console
root@beans:~#
```

where as with this change the output will be: 

```
root@ircdoos:~# lspci -nn
00:00.0 Host bridge [0600]: Intel Corporation 440FX - 82441FX PMC [Natoma] [8086:1237] (rev 02)
00:01.0 ISA bridge [0601]: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II] [8086:7000]
00:01.1 IDE interface [0101]: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II] [8086:7010]
00:01.2 USB controller [0c03]: Intel Corporation 82371SB PIIX3 USB [Natoma/Triton II] [8086:7020] (rev 01)
00:01.3 Bridge [0680]: Intel Corporation 82371AB/EB/MB PIIX4 ACPI [8086:7113] (rev 03)
00:02.0 VGA compatible controller [0300]: Device [1234:1111] (rev 02)
00:03.0 Ethernet controller [0200]: Red Hat, Inc Virtio network device [1af4:1000]
00:04.0 SCSI storage controller [0100]: Red Hat, Inc Virtio SCSI [1af4:1004]
00:05.0 Unclassified device [00ff]: Red Hat, Inc Virtio memory balloon [1af4:1002]
00:06.0 Communication controller [0780]: Red Hat, Inc Virtio console [1af4:1003]
root@ircdoos:~#
```

Feedback is appreciated.

Thank you.