### PR TITLE
Tweaks to --btrfsinfo

### DIFF
--- a/fpaste
+++ b/fpaste
@@ -110,9 +110,9 @@ btrfs_cmdlist = [
      ),
     ('btrfs mounts', '''grep btrfs /proc/mounts'''
      ),
-    ('block devices', '''lsblk -ft'''
+    ('block devices', '''lsblk -o NAME,FSTYPE,SIZE,FSUSE%,MOUNTPOINT,UUID,MIN-IO,SCHED,DISC-GRAN,MODEL'''
      ),
-    ('Kernel messages', '''journalctl -o short-monotonic --no-hostname -k'''
+    ('Kernel messages', '''journalctl -k -o short-monotonic --no-hostname | grep "Linux version\| ata\|Btrfs\|BTRFS\|] hd\| scsi\| sd\| sdhci\| mmc\| nvme\| usb\| vd"'''
      ),
     ('btrfs usage',   '''btrfs filesystem usage -T /'''),
 ]


### PR DESCRIPTION
Gather more explicit 'lsblk' info, also helps format better in the
fpaste server. Collect less 'dmesg' info, by filtering for
things that tend to show obvious problems.